### PR TITLE
Removed STACK-X Meetups hyperlink, corrected open source tech hyperlink naming

### DIFF
--- a/pages/digital-government-journey/citizen-engagement-and-cocreation/catalysing-public-private-innovation-and-co-creation-through-an-open-and-accessible-government.md
+++ b/pages/digital-government-journey/citizen-engagement-and-cocreation/catalysing-public-private-innovation-and-co-creation-through-an-open-and-accessible-government.md
@@ -31,5 +31,4 @@ Tech Kaki is a user insights community set up by GovTech to encourage citizen en
 Find out more about our public-private innovation and co-creation opportunities here:
 *	[Open-source technologies](https://www.developer.tech.gov.sg/technologies/open-source/){:target="_blank"}
 *	[STACK Community](https://www.developer.tech.gov.sg/communities/events/overview){:target="_blank"}
-*	[STACK-X Meetups](https://www.developer.tech.gov.sg/communities/stack-x-meetups/overview.html){:target="_blank"}
 *	[Tech Kaki](https://www.tech.gov.sg/products-and-services/tech-kaki-community/){:target="_blank"}

--- a/pages/digital-government-journey/citizen-engagement-and-cocreation/catalysing-public-private-innovation-and-co-creation-through-an-open-and-accessible-government.md
+++ b/pages/digital-government-journey/citizen-engagement-and-cocreation/catalysing-public-private-innovation-and-co-creation-through-an-open-and-accessible-government.md
@@ -29,6 +29,6 @@ The STACK community comprises of the STACK, STACK-X and Capture-the-Flag communi
 Tech Kaki is a user insights community set up by GovTech to encourage citizen engagement and co-creation. Community tech enthusiasts get first-hand information on new tech products before launch, and are invited to participate in surveys and highlight areas for improvement.
 
 Find out more about our public-private innovation and co-creation opportunities here:
-*	[Open-source technologies](https://www.developer.tech.gov.sg/technologies/open-source/){:target="_blank"}
+*	[Open-source Tech](https://www.developer.tech.gov.sg/technologies/open-source/){:target="_blank"}
 *	[STACK Community](https://www.developer.tech.gov.sg/communities/events/overview){:target="_blank"}
 *	[Tech Kaki](https://www.tech.gov.sg/products-and-services/tech-kaki-community/){:target="_blank"}


### PR DESCRIPTION
Edits made:
1. Removed STACK-X meetups hyperlink
2. Renamed open source technologies hyperlink to open source tech as per the write up