### PR TITLE
Correction of typo

### DIFF
--- a/_careers/4-students-and-graduates.md
+++ b/_careers/4-students-and-graduates.md
@@ -61,7 +61,6 @@ An exclusive leadership-trainee programme, TAP is designed to sharpen and develo
 ![Alternative text for screen readers](/images/careers/TAP_Infographic.png)   
 
 **How can you apply?**
-<br> Applications are open from 1 May to 31 July 2021. If you are passionate about the use of technology to shape our future and better the lives of Singaporeans, join us to make an impact! [Apply Now](https://go.gov.sg/govtech-tap)!
+<br> Applications will be open from 1 June to 31 August 2022. If you are passionate about the use of technology to shape our future and better the lives of Singaporeans, join us to make an impact! You may indicate your interest at the link provided so that we can notify you when application is open. [Register Now](https://go.gov.sg/govtechtalentcommunity)!
 
 To receive updates about our Young Talent programmes, join our [community](https://go.gov.sg/govtechtalentcommunity).
-

--- a/media/corporate-publications/_posts/2022-01-24-digital-government-exchange-reports.md
+++ b/media/corporate-publications/_posts/2022-01-24-digital-government-exchange-reports.md
@@ -34,6 +34,6 @@ Our working groups have produced in depth reports studying various digital gover
 **DGX WGs 2021**
 - [Cloud governance by the DGX Cloud Working Group](/files/media/corporate-publications/FY2021/DGX Cloud Working Group Report 2021 - Baseline Policies.pdf){:target="_blank"}
 - ["Digital Identity in response to COVID-19" by the DGX Digital Identity Working Group](/files/media/corporate-publications/FY2021/dgx_2021_digital_identity_in_response_to_covid-19.pdf){:target="_blank"}
-- [Dgitial Maturity Minimum Viable Product (MVP) framework by the DGX Digital Identity Working Group](/files/media/corporate-publications/FY2021/DGX Digital Maturity Working Group Report 2021 - Digital Maturity MVP.pdf){:target="_blank"}
+- [Digitial Maturity Minimum Viable Product (MVP) framework by the DGX Digital Identity Working Group](/files/media/corporate-publications/FY2021/DGX Digital Maturity Working Group Report 2021 - Digital Maturity MVP.pdf){:target="_blank"}
 
 Feel free to contact us at <tmo@tech.gov.sg> for more information.


### PR DESCRIPTION
Typo in last bullet point for the DGX working group reports.

Previously it was :dgital..." it has been corrected to "digital..."